### PR TITLE
fix: synchronize terminal size with vim window

### DIFF
--- a/autoload/vim_yazi.vim
+++ b/autoload/vim_yazi.vim
@@ -62,6 +62,8 @@ function! vim_yazi#LaunchYazi(path)
     let term_buf = term_start(yazi_cmd, {
       \ 'exit_cb': function('vim_yazi#OnYaziExit'),
       \ 'term_finish': 'close',
+      \ 'term_rows': winheight('%'),
+      \ 'term_cols': winwidth('%'),
       \ 'curwin': 1,
     \ })
   else


### PR DESCRIPTION
### Summary
This pull request adds the following options to the `term_start()` call:
```vim
   \ 'term_rows': winheight('%'),
   \ 'term_cols': winwidth('%'),
```

### Motivation
By explicitly setting the terminal size to match the current window dimensions, this change ensures that the terminal always launches at full size by window. This avoids inconsistencies caused by settings like `termwinsize`, and improves the usability of the plugin when using terminal windows.

This plugin is really great. While netrw is sufficient, its key mappings aren't very intuitive. I’d like to continue using this plugin.