### PR TITLE
fix: correct behavior of YaziOpen with empty arguments (and add YaziCwd command)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Plug 'yukimura1227/vim-yazi'
 | Command | Description |
 |---------|-------------|
 | `:Yazi [path]` | Launch yazi in the specified directory (defaults to current file's directory) |
+| `:YaziCwd` | Launch yazi in the current working directory (equivalent to `:Yazi .`) |
 
 ### Default Key Mappings
 
@@ -94,7 +95,7 @@ nnoremap <silent> <C-n> :Yazi<CR>
 ### Basic Usage
 
 ```vim
-" Open yazi in current directory
+" Open yazi in current file's directory
 :Yazi
 
 " Open yazi in a specific directory

--- a/autoload/vim_yazi.vim
+++ b/autoload/vim_yazi.vim
@@ -72,8 +72,8 @@ function! vim_yazi#LaunchYazi(path)
   endif
 endfunction
 
-function! vim_yazi#YaziOpen(...)
-  let path = a:0 > 0 ? a:1 : expand('%:p:h')
+function! vim_yazi#YaziOpen(path)
+  let path = empty(a:path) ? expand('%:p:h') : a:path
   call vim_yazi#LaunchYazi(path)
 endfunction
 

--- a/doc/vim-yazi.txt
+++ b/doc/vim-yazi.txt
@@ -32,6 +32,9 @@ COMMANDS                                            *vim-yazi-commands*
 :Yazi [path]                                        *:Yazi*
 Launch yazi in the specified directory (defaults to current file's directory) |
 
+:YaziCwd                                            *:YaziCwd*
+Launch yazi in the current working directory (equivalent to :Yazi .)
+
 ------------------------------------------------------------------------------
 KEY-MAPPINGS                                        *vim-yazi-key-mappings*
 

--- a/plugin/vim-yazi.vim
+++ b/plugin/vim-yazi.vim
@@ -35,6 +35,7 @@ endif
 " Define commands
 """"""""""""""""""""""""""""""""""""""""
 command! -nargs=? -complete=dir Yazi call vim_yazi#YaziOpen(<q-args>)
+command! -nargs=0 YaziCwd Yazi .
 
 """"""""""""""""""""""""""""""""""""""""
 " Default KeyMap


### PR DESCRIPTION
## Overview

- Changed `vim_yazi#YaziOpen` to accept a single `path` argument instead of multiple arguments.
- Now checks the argument with `empty()` and opens the current buffer’s directory if the argument is empty.
- Previously, with `command! -nargs=? -complete=dir Yazi call vim_yazi#YaziOpen(<q-args>)`, if the command argument was empty, `<q-args>` would become an empty string, which led to opening `getcwd()`.  
  The new implementation consistently opens the buffer’s directory when the argument is empty.
- Added a utility command `YaziCwd` to open the current working directory (`getcwd()`).

---

## Reason for Changes

- Due to the behavior of `<q-args>`, an empty argument results in an empty string being passed.  
  In the previous implementation, this could unintentionally open the result of `getcwd()`.
- Introduced `YaziCwd` for a more intuitive way to open the working directory via a dedicated command.

## NOTE for `<q-args>`

The bolded text is what i am referring to in the PR description.
following documentation is from `:h <q-args>`

> If the first two characters of an escape sequence are "q-" (for example,
> `<q-args>`) then the value is quoted in such a way as to make it a valid value
> for use in an expression.  This uses the argument as one single value.
> **When there is no argument `<q-args>` is an empty string**.  See the
> |q-args-example| below.
