### PR TITLE
feat: pass current file as entry point when launching yazi

### DIFF
--- a/autoload/vim_yazi.vim
+++ b/autoload/vim_yazi.vim
@@ -37,7 +37,7 @@ function! vim_yazi#CreateFloatingWindow() abort
   return win
 endfunction
 
-function! vim_yazi#LaunchYazi(path)
+function! vim_yazi#LaunchYazi(path, entry = '')
   if !vim_yazi#CheckYaziAvailable()
     return
   endif
@@ -47,7 +47,7 @@ function! vim_yazi#LaunchYazi(path)
     " using parent directory
     let initial_path = fnamemodify(initial_path, ':h')
   endif
-  let yazi_cmd = g:yazi_executable . ' --chooser-file=' . shellescape(s:selection_file)
+  let yazi_cmd = g:yazi_executable . ' ' . a:entry . ' --chooser-file=' . shellescape(s:selection_file)
   let yazi_cmd .= ' ' . shellescape(initial_path)
   let yazi_cmd = 'sh -c "' . yazi_cmd . '"'
 
@@ -73,8 +73,9 @@ function! vim_yazi#LaunchYazi(path)
 endfunction
 
 function! vim_yazi#YaziOpen(...)
+  let entry = a:0 > 0 && !empty(a:1) ? '' : expand('%')
   let path = a:0 > 0 ? a:1 : expand('%:p:h')
-  call vim_yazi#LaunchYazi(path)
+  call vim_yazi#LaunchYazi(path, entry)
 endfunction
 
 function! vim_yazi#OpenSelectedFiles()


### PR DESCRIPTION
  ## Summary
  - Add support for passing the current file as entry point when launching yazi
  - This allows yazi to start with the current file already selected/highlighted

  ## Changes
  - Modified `vim_yazi#LaunchYazi()` to accept an optional `entry` parameter
  - Updated `vim_yazi#YaziOpen()` to pass current file as entry when no path argument is provided
  - Enhanced yazi command construction to include the entry parameter

  ## Merge Conflicts
  This PR modifies the `vim_yazi#YaziOpen(...)` function signature, which conflicts with PR #2 that changes it to `vim_yazi#YaziOpen(path)`.
  - If PR #2 merges first, this PR will need to be updated to accommodate the function signature change
  - If this PR merges first, PR #2 will need to be updated accordingly
  - Both PRs are mine, so I will resolve the conflicts as needed
