### PR TITLE
fix: allow opening yazi with file paths instead of only directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Plug 'yukimura1227/vim-yazi'
 
 | Command | Description |
 |---------|-------------|
-| `:Yazi [path]` | Launch yazi in the specified directory (defaults to current file's directory) |
+| `:Yazi [path]` | Launch yazi in the specified path (defaults to current file) |
 
 ### Default Key Mappings
 
@@ -94,10 +94,10 @@ nnoremap <silent> <C-n> :Yazi<CR>
 ### Basic Usage
 
 ```vim
-" Open yazi in current directory
+" Open yazi in current file
 :Yazi
 
-" Open yazi in a specific directory
+" Open yazi in a specific path
 :Yazi ~/Documents
 ```
 

--- a/autoload/vim_yazi.vim
+++ b/autoload/vim_yazi.vim
@@ -43,10 +43,6 @@ function! vim_yazi#LaunchYazi(path)
   endif
 
   let initial_path = empty(a:path) ? getcwd() : a:path
-  if !isdirectory(initial_path)
-    " using parent directory
-    let initial_path = fnamemodify(initial_path, ':h')
-  endif
   let yazi_cmd = g:yazi_executable . ' --chooser-file=' . shellescape(s:selection_file)
   let yazi_cmd .= ' ' . shellescape(initial_path)
   let yazi_cmd = 'sh -c "' . yazi_cmd . '"'
@@ -73,7 +69,7 @@ function! vim_yazi#LaunchYazi(path)
 endfunction
 
 function! vim_yazi#YaziOpen(...)
-  let path = a:0 > 0 ? a:1 : expand('%:p:h')
+  let path = a:0 > 0 && !empty(a:1) ? a:1 : expand('%:p')
   call vim_yazi#LaunchYazi(path)
 endfunction
 

--- a/plugin/vim-yazi.vim
+++ b/plugin/vim-yazi.vim
@@ -34,7 +34,7 @@ endif
 """"""""""""""""""""""""""""""""""""""""
 " Define commands
 """"""""""""""""""""""""""""""""""""""""
-command! -nargs=? -complete=dir Yazi call vim_yazi#YaziOpen(<q-args>)
+command! -nargs=? -complete=file Yazi call vim_yazi#YaziOpen(<q-args>)
 
 """"""""""""""""""""""""""""""""""""""""
 " Default KeyMap


### PR DESCRIPTION
  ## Summary
  - Remove directory check that forced file paths to be converted to parent directories
  - Allow yazi to open with specific files selected instead of only directories
  - Update default behavior to pass current file path instead of parent directory

  ## Changes
  - Removed `isdirectory()` check and `fnamemodify()` conversion in `vim_yazi#LaunchYazi()`
  - Changed default path from `expand('%:p:h')` to `expand('%:p')` in `vim_yazi#YaziOpen()`
  - Added empty check `!empty(a:1)` to properly handle empty string arguments

  ## Behavior Changes
  - `:Yazi` without arguments now opens yazi with the current file highlighted
  - `:Yazi /path/to/file.txt` now opens yazi with that specific file selected
  - Directory paths continue to work as before
  
  ## Merge Conflicts
  This PR modifies the `vim_yazi#YaziOpen(...)` function, which may conflict with PR #2 that changes the function signature.
 Whichever PR merges first, I will update the remaining one to resolve any conflicts accordingly.
